### PR TITLE
[vlan] Add OUTER_TAG to accel-ppp config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,7 @@ services:
       - ./config/accel-pppd/etc/accel-ppp.conf:/etc/accel-ppp.conf
     environment:
       - IFACE=eth1
+      - OUTER_TAG=700
  telnet_downlink:
     build: ./telnet
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,9 @@ services:
       - ./config/accel-pppd/etc/accel-ppp.conf:/etc/accel-ppp.conf
     environment:
       - IFACE=eth1
+      - OUTER_PROTO=802.1Q
       - OUTER_TAG=700
+      - INNER_PROTO=802.1Q
  telnet_downlink:
     build: ./telnet
     networks:


### PR DESCRIPTION
This new option let you specify the outer tag. We moved to using double
C-tags for now, so the environment variables changed. 700 is default but
adding this config option here is kind of documentation.