### PR TITLE
Submodule URL from ssh to https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/dpdk-vbng-cp/docker-accel-ppp.git
 [submodule "bng-utils"]
 	path = bng-utils
-	url = git@github.com:dpdk-vbng-cp/bng-utils.git
+	url = https://github.com/dpdk-vbng-cp/bng-utils.git


### PR DESCRIPTION
To avoid the ssh permission denied error when running `git submodule --init`, this PR changes the submodules URL from ssh to https
